### PR TITLE
Fix weighted classes with unstated 0% categories

### DIFF
--- a/js/grades.js
+++ b/js/grades.js
@@ -442,27 +442,39 @@ function createEditListener(gradeColContentWrap, catRow, perRow, finishedCallbac
                 awardedPeriodPercent.textContent = (Math.round(newPerPercent * 100) / 100) + "%";
             } else {
                 let total = 0;
-                let totalPercent = 0;
-                let categories = perRow.parentElement.getElementsByClassName("category-row");
-                for (let category of categories) {
-                    let weightPercent = category.querySelector(".percentage-contrib").textContent;
-                    let roundedGrade = category.querySelector(".rounded-grade");
-                    let maxGrade = category.querySelector(".max-grade");
-                    if (roundedGrade && maxGrade && roundedGrade.textContent != "0" || maxGrade.textContent.slice(3) != "0") {
-                        totalPercent += Number.parseFloat(weightPercent.slice(1, -2));
+                let totalPercentWeight = 0;
+                for (let category of perRow.parentElement.getElementsByClassName("category-row")) {
+                    let weightPercentElement = category.getElementsByClassName("percentage-contrib")[0];
+                    if (!weightPercentElement) {
+                        continue;
                     }
-                }
-                for (let category of categories) {
-                    let weightPercent = category.querySelector(".percentage-contrib").textContent;
-                    let col = category.querySelector(".grade-column-right");
+                    let weightPercent = weightPercentElement.textContent;
+                    let col = category.getElementsByClassName("grade-column-right")[0];
                     let colMatch = col ? col.textContent.match(/(\d+\.?\d*)%/) : null;
                     if (colMatch) {
                         let scorePercent = Number.parseFloat(colMatch[1]);
-                        total += (weightPercent.slice(1, -2) / totalPercent) * scorePercent;
-                        awardedPeriodPercent.title = total + "%";
-                        awardedPeriodPercent.textContent = (Math.round(total * 100) / 100) + "%";
+                        if (scorePercent && !Number.isNaN(scorePercent)) {
+                            total += (weightPercent.slice(1, -2) / 100) * scorePercent;
+                            totalPercentWeight += Number.parseFloat(weightPercent.slice(1, -2));
+                        }
                     }
                 }
+
+                totalPercentWeight /= 100;
+
+                // if only some categories have assignments, adjust the total accordingly 
+                // if weights are more than 100, this assumes that it's correct as intended (e.c.), I won't mess with it
+                if (totalPercentWeight > 0 && totalPercentWeight < 1) {
+                    // some categories are specified, but weights don't quite add to 100
+                    // scale up known grades
+                    total /= totalPercentWeight;
+                // epsilon because floating point
+                } else if (totalPercentWeight < 0.00001) {
+                    total = 100;
+                }
+
+                awardedPeriodPercent.title = total + "%";
+awardedPeriodPercent.textContent = (Math.round(total * 100) / 100) + "%";
             }
 
             if (!awardedPeriodPercentContainer.querySelector(".modified-score-percent-warning")) {

--- a/js/grades.js
+++ b/js/grades.js
@@ -474,7 +474,7 @@ function createEditListener(gradeColContentWrap, catRow, perRow, finishedCallbac
                 }
 
                 awardedPeriodPercent.title = total + "%";
-awardedPeriodPercent.textContent = (Math.round(total * 100) / 100) + "%";
+                awardedPeriodPercent.textContent = (Math.round(total * 100) / 100) + "%";
             }
 
             if (!awardedPeriodPercentContainer.querySelector(".modified-score-percent-warning")) {

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,11 @@
         "32": "imgs/icon@32.png",
         "16": "imgs/icon@16.png"
     },
+    "applications": {
+        "gecko": {
+            "id": "schoologyplus@aopell.me"
+        }
+    },
     "browser_action": {
         "default_icon": {
             "16": "imgs/icon@16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -10,12 +10,7 @@
         "48": "imgs/icon@48.png",
         "32": "imgs/icon@32.png",
         "16": "imgs/icon@16.png"
-    },
-    "applications": {
-        "gecko": {
-            "id": "schoologyplus@aopell.me"
-        }
-    },
+    }
     "browser_action": {
         "default_icon": {
             "16": "imgs/icon@16.png",


### PR DESCRIPTION
Fixes grade editing in weighted classes where some categories don't have a weight stated. In these cases, the weight is 0%.

Also adds an extension ID for gecko browsers (Firefox) to allow local storage to be used. I made up this extension ID, it can also be a GUID if we want but if this is unique it should be fine.