### PR TITLE
Improve assignment tooltip generation (performance, minor styling, dropped indication)

### DIFF
--- a/css/materials.css
+++ b/css/materials.css
@@ -29,6 +29,27 @@
     font-size: 10px;
 }
 
+.assignment-tooltip .tooltip-dropped-indicator {
+    color: #00ff00;
+    font-size: 9px;
+    font-weight: bold;
+}
+
+.assignment-tooltip .tooltip-dropped-gradeinfo {
+    font-size: 50%;
+    /* text-decoration: line-through; */ /* Off-center and bad looking */
+}
+
+.assignment-tooltip .tooltip-dropped-gradeinfo::before {
+    content: "[";
+    color: #781b8f;
+}
+
+.assignment-tooltip .tooltip-dropped-gradeinfo::after {
+    content: "]";
+    color: #781b8f;
+}
+
 .assignment-tooltip .tooltip-grade-info {
     color: #94cfff;
 }

--- a/css/materials.css
+++ b/css/materials.css
@@ -32,3 +32,7 @@
 .assignment-tooltip .tooltip-grade-info {
     color: #94cfff;
 }
+
+.assignment-tooltip .tooltip-grade-info .tooltip-horiz-divider {
+    color: #6f99bb;
+}

--- a/css/materials.css
+++ b/css/materials.css
@@ -31,23 +31,23 @@
 
 .assignment-tooltip .tooltip-dropped-indicator {
     color: #00ff00;
-    font-size: 9px;
     font-weight: bold;
 }
 
+/*
 .assignment-tooltip .tooltip-dropped-gradeinfo {
-    font-size: 50%;
-    /* text-decoration: line-through; */ /* Off-center and bad looking */
+    text-decoration: line-through;
 }
+*/
 
 .assignment-tooltip .tooltip-dropped-gradeinfo::before {
     content: "[";
-    color: #781b8f;
+    color: #aa42c4;
 }
 
 .assignment-tooltip .tooltip-dropped-gradeinfo::after {
     content: "]";
-    color: #781b8f;
+    color: #aa42c4;
 }
 
 .assignment-tooltip .tooltip-grade-info {

--- a/js/materials.js
+++ b/js/materials.js
@@ -62,7 +62,7 @@
                     innerContent += "<span class=\"exception-missing\">Missing</span>";
                 } else if (assignment.grade !== null) {
                     // normal grade status, has a grade
-                    let gradeElem = wrapHtml(escapeForHtml(assignment.grade), "span", { class: "tooltip-grade-numerator" });
+                    let gradeElem = wrapHtml(escapeForHtml((!assignment.max_points && assignment.grade >= 0 ? "+" : "") + assignment.grade), "span", { class: "tooltip-grade-numerator" });
                     if (assignment.max_points) {
                         gradeElem += " <span class=\"tooltip-horiz-divider\">/</span> ";
                         gradeElem += wrapHtml(escapeForHtml(assignment.max_points, "span", { class: "tooltip-grade-denominator" }));

--- a/js/materials.js
+++ b/js/materials.js
@@ -83,10 +83,10 @@
 
                 if (grades.gradeDrops[assignmentId]) {
                     // assignment dropped
-                    innerContent = wrapHtml("Dropped", "p", { class: "tooltip-dropped-indicator" }) + wrapHtml(innerContent, "p", { class: "tooltip-dropped-gradeinfo" });
-                } else {
-                    innerContent = wrapHtml(innerContent, "p");
+                    innerContent = wrapHtml("Dropped", "span", { class: "tooltip-dropped-indicator" }) + " " + wrapHtml(innerContent, "span", { class: "tooltip-dropped-gradeinfo" });
                 }
+
+                innerContent = wrapHtml(innerContent, "p");
 
                 let footerElements = [];
                 if (assignment.category_id && grades.categories[assignment.category_id]) {

--- a/js/materials.js
+++ b/js/materials.js
@@ -64,7 +64,7 @@
                     // normal grade status, has a grade
                     let gradeElem = wrapHtml(escapeForHtml(assignment.grade), "span", { class: "tooltip-grade-numerator" });
                     if (assignment.max_points) {
-                        gradeElem += " / ";
+                        gradeElem += " <span class=\"tooltip-horiz-divider\">/</span> ";
                         gradeElem += wrapHtml(escapeForHtml(assignment.max_points, "span", { class: "tooltip-grade-denominator" }));
                     } else {
                         gradeElem += " pts";


### PR DESCRIPTION
No associated issue ticket.
Does not address @aopell's comment on #37 (does not add letter grade display), although this should be fairly straightforward (and will be discussed a few paragraphs down).

Improve, in a few ways, the generation of tooltips for assignments on the materials page. Improvements include:
- Performance. In many cases, an API call per assignment is no longer necessary. Note that this comes at the **cost of showing all submission statuses**. Getting "dropbox" status required a call per assignment, so in cases where a normal (non-exception non-empty) grade has been entered into the assignment, the call is omitted and the status not displayed. This improves performance markedly for two reasons: in my environment, most assignments have `allow_dropbox` set even though they shouldn't, so once they are graded the call goes away now; if it's been processed teacher-side, the submission status isn't relevant anymore, so it's not worth time to display it.
- Reliability. Related to dropbox tweaks above; for some reason on some classes the assignments API call doesn't get everything. We don't use it in tooltip generation outside of for dropbox logic, but regardless, for missing assignments we now acquire that via the specific-assignment API call. **Potential improvement:** we could limit ourselves to only querying assignments O(n) if they'd be likely to need a dropbox call; this would save time in the cases where /assignments is not reliable but everything's graded. That said I've only seen this nonreliability behavior on one class so it might not be worth optimizing for.
- Styling tweaks in grade tooltip. Slightly darker slash for normal grades and a plus sign ("+5 pts") for extra-credit grades.
- Dropped grade display in tooltip. Currently takes the form of a bold, green "Dropped" followed by the normal point/grade display in purple brackets. I'm not super happy with the styling, but I do like the idea of displaying dropped assignments. I considered putting "Dropped" on its own line above, but I don't think the points and the dropped text should have visual equivalence, and I didn't find a good way not to do that with vertical layout.

Regarding the letter grade: there is a field in the API for "calculated_grade," or letter grade on the teacher's Schoology-side grading scale, but few classes in my environment use this and fewer yet use it properly. Since we already have infrastructure for client-side grading scales, that's what we should use; I worry a bit about it taking up too much screen real estate, and I also am not sure that letter grades for every assignment in this context is a good idea (for categories and classes 100% I agree add letter grades where possible, but for assignments I'm not so sure). On the grades page we don't show assignment letter grades (nor do we mess with them when teachers provide, unless the user edits a grade, I think), but we do show percentages; that might be a better alternative here, but it has a heftier real estate requirement.