### PR TITLE
Add kebab menu to assignments

### DIFF
--- a/css/grades.css
+++ b/css/grades.css
@@ -146,6 +146,7 @@ input#enable-modify {
 }
 
 .kabob-menu {
+    margin-left: 10px;
     font-size: 16px;
     font-weight: normal;
     float: right;

--- a/css/grades.css
+++ b/css/grades.css
@@ -144,3 +144,18 @@ input#enable-modify {
     font-size: 12px;
     font-weight: normal;
 }
+
+.kabob-menu {
+    font-size: 16px;
+    font-weight: normal;
+    float: right;
+    cursor: pointer;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.grade-add-indicator .kabob-menu {
+    display: none;
+}

--- a/js/grades.js
+++ b/js/grades.js
@@ -131,6 +131,25 @@ var fetchQueue = [];
                     //assignment.style.padding = "7px 30px 5px";
                     //assignment.style.textAlign = "center";
 
+                    // kabob menu
+                    let commentsContentWrapper = assignment.querySelector(".comment-column").firstElementChild;
+                    let kabobMenuButton = createElement("span", ["kabob-menu"], {
+                        textContent: "⠇",
+                        onclick: function (event) {
+                            console.log(event);
+                            $(assignment).contextMenu({ x: event.pageX, y: event.pageY });
+                        }
+                    });
+
+                    let editEnableCheckbox = document.getElementById("enable-modify");
+
+                    // not created yet and thus editing disabled, or created the toggle but editing disabled
+                    if (!editEnableCheckbox || !editEnableCheckbox.checked) {
+                        kabobMenuButton.classList.add("hidden");
+                    }
+
+                    commentsContentWrapper.insertAdjacentElement("beforeend", kabobMenuButton);
+
                     let createAddAssignmentUi = async function () {
                         //.insertAdjacentElement('afterend', document.createElement("div"))
                         let addAssignmentThing = createElement("tr", ["report-row", "item-row", "last-row-of-tier", "grade-add-indicator"]);
@@ -551,6 +570,10 @@ var fetchQueue = [];
                             }
                         }
                     });
+
+                    for (let kabob of document.getElementsByClassName("kabob-menu")) {
+                        kabob.classList.remove("hidden");
+                    }
                 } else if (!gradesModified) {
                     for (let edit of document.getElementsByClassName("grade-edit-indicator")) {
                         edit.style.display = "none";
@@ -560,6 +583,9 @@ var fetchQueue = [];
                         if (edit.previousElementSibling.classList.contains("item-row") && !edit.previousElementSibling.classList.contains("last-row-of-tier")) {
                             edit.previousElementSibling.classList.add("last-row-of-tier");
                         }
+                    }
+                    for (let kabob of document.getElementsByClassName("kabob-menu")) {
+                        kabob.classList.add("hidden");
                     }
                     for (let courseElement of document.getElementsByClassName("gradebook-course")) {
                         $.contextMenu("destroy", "#" + courseElement.id + " " + undroppedAssignRClickSelector);

--- a/js/grades.js
+++ b/js/grades.js
@@ -136,7 +136,6 @@ var fetchQueue = [];
                     let kabobMenuButton = createElement("span", ["kabob-menu"], {
                         textContent: "⠇",
                         onclick: function (event) {
-                            console.log(event);
                             $(assignment).contextMenu({ x: event.pageX, y: event.pageY });
                         }
                     });
@@ -149,6 +148,9 @@ var fetchQueue = [];
                     }
 
                     commentsContentWrapper.insertAdjacentElement("beforeend", kabobMenuButton);
+                    if(commentsContentWrapper.querySelector(".comment")) {
+                        commentsContentWrapper.style.display = "flex";
+                    }
 
                     let createAddAssignmentUi = async function () {
                         //.insertAdjacentElement('afterend', document.createElement("div"))


### PR DESCRIPTION
Adds a kebab menu to assignments, a more discoverable alternative to the right-click menu for editable assignments.

It's the same menu as the right-click menu; it is another way to open it. This approach avoids code duplication.

Fixes #78.

Screenshot:
![image](https://user-images.githubusercontent.com/3952667/48961625-fdc4d400-ef2a-11e8-998b-5636974c66a1.png)

**Drawbacks:**
- Abuses the comments column, and interferes with document flow (thus visually interfering with comments when present) without otherwise adjusting the column. Note how Test 4 displays.
![image](https://user-images.githubusercontent.com/3952667/48961662-382e7100-ef2b-11e8-927a-2d291190392b.png)
If we can fix this before merging I would like that.
- Abuses [Unicode](http://www.fileformat.info/info/unicode/char/2807/index.htm). Potential [alternative character](https://www.fileformat.info/info/unicode/char/22ee/browsertest.htm).