### PR TITLE
Refactor Schoology API fetch calls

### DIFF
--- a/js/all-idle.js
+++ b/js/all-idle.js
@@ -95,17 +95,12 @@
     if (storage.courseAliases) {
         let apiKeys = await getApiKeys();
 
-        let myClassData = await fetch(`https://api.schoology.com/v1/users/${apiKeys[2]}/sections`, {
-            headers: createApiAuthenticationHeaders(apiKeys)
-        });
-        let myClasses = (await myClassData.json()).section;
+        let myClasses = (await fetchApiJson(`/users/${apiKeys[2]}/sections`)).section;
 
         // get course info for courses with aliases that I'm not currently enrolled in, concurrently
         myClasses.push(...await Promise.all(Object.keys(storage.courseAliases).filter(aliasedCourseId => !myClasses.some(x => x.id == aliasedCourseId))
             .filter(aliasedCourseId => storage.courseAliases[aliasedCourseId]) // only fetch if the alias hasn't subsequently been cleared
-            .map(id => fetch(`https://api.schoology.com/v1/sections/${id}`, {
-                headers: createApiAuthenticationHeaders(apiKeys)
-            }).then(resp => resp.json().catch(rej => null), rej => null))));
+            .map(id => fetchApi(`/sections/${id}`).then(resp => resp.json().catch(rej => null), rej => null))));
 
         console.log("Classes loaded, building alias stylesheet");
         // https://stackoverflow.com/a/707794 for stylesheet insertion

--- a/js/all-idle.js
+++ b/js/all-idle.js
@@ -93,9 +93,7 @@
 
     // PREP COURSE ALIASES
     if (storage.courseAliases) {
-        let apiKeys = await getApiKeys();
-
-        let myClasses = (await fetchApiJson(`/users/${apiKeys[2]}/sections`)).section;
+        let myClasses = (await fetchApiJson(`/users/${getUserId()}/sections`)).section;
 
         // get course info for courses with aliases that I'm not currently enrolled in, concurrently
         myClasses.push(...await Promise.all(Object.keys(storage.courseAliases).filter(aliasedCourseId => !myClasses.some(x => x.id == aliasedCourseId))

--- a/js/grades.js
+++ b/js/grades.js
@@ -40,8 +40,6 @@ var fetchQueue = [];
 (async function () {
     console.log("Running Schoology Plus grades page improvement script");
 
-    let apiKeys = await getApiKeys();
-
     let inner = document.getElementById("main-inner") || document.getElementById("content-wrapper");
     let courses = inner.getElementsByClassName("gradebook-course");
     let coursesByPeriod = [];
@@ -108,22 +106,20 @@ var fetchQueue = [];
                         maxGrade.parentElement.appendChild(newGrade);
                     }
                     else {
-                        queueNonenteredAssignment(assignment, apiKeys, courseId);
+                        queueNonenteredAssignment(assignment, courseId);
                     }
                     if (assignment.querySelector(".missing")) {
                         // get denominator for missing assignment
-                        if (apiKeys) {
-                            let p = assignment.querySelector(".injected-assignment-percent");
-                            p.textContent = "0%";
-                            p.title = "Assignment missing";
-                            console.log(`Fetching max points for assignment ${assignment.dataset.id.substr(2)}`);
-                            let json = await fetchApiJson(`/sections/${courseId}/assignments/${assignment.dataset.id.substr(2)}`);
+                        let p = assignment.querySelector(".injected-assignment-percent");
+                        p.textContent = "0%";
+                        p.title = "Assignment missing";
+                        console.log(`Fetching max points for assignment ${assignment.dataset.id.substr(2)}`);
+                        let json = await fetchApiJson(`/sections/${courseId}/assignments/${assignment.dataset.id.substr(2)}`);
 
-                            let pts = Number.parseFloat(json.max_points);
-                            if (!assignment.classList.contains("dropped")) {
-                                max += pts;
-                                console.log(`Max points for assignment ${assignment.dataset.id.substr(2)} is ${pts}`);
-                            }
+                        let pts = Number.parseFloat(json.max_points);
+                        if (!assignment.classList.contains("dropped")) {
+                            max += pts;
+                            console.log(`Max points for assignment ${assignment.dataset.id.substr(2)} is ${pts}`);
                         }
                     }
                     //assignment.style.padding = "7px 30px 5px";
@@ -646,7 +642,7 @@ var fetchQueue = [];
         return "?";
     }
 
-    function queueNonenteredAssignment(assignment, apiKeys, courseId) {
+    function queueNonenteredAssignment(assignment, courseId) {
         let noGrade = assignment.getElementsByClassName("no-grade")[0];
 
         if (noGrade.parentElement.classList.contains("exception-grade-wrapper")) {
@@ -663,7 +659,7 @@ var fetchQueue = [];
             }
         }
 
-        if (noGrade && apiKeys && assignment.dataset.id) {
+        if (noGrade && assignment.dataset.id) {
             // do this while the other operation is happening so we don't block the page load
             // don't block on it
 

--- a/js/grades.js
+++ b/js/grades.js
@@ -117,11 +117,7 @@ var fetchQueue = [];
                             p.textContent = "0%";
                             p.title = "Assignment missing";
                             console.log(`Fetching max points for assignment ${assignment.dataset.id.substr(2)}`);
-                            let json = await (
-                                await fetch(`https://api.schoology.com/v1/sections/${courseId}/assignments/${assignment.dataset.id.substr(2)}`, {
-                                    headers: createApiAuthenticationHeaders(apiKeys)
-                                })
-                            ).json();
+                            let json = await fetchApiJson(`/sections/${courseId}/assignments/${assignment.dataset.id.substr(2)}`);
 
                             let pts = Number.parseFloat(json.max_points);
                             if (!assignment.classList.contains("dropped")) {
@@ -679,9 +675,7 @@ var fetchQueue = [];
 
             let f = async () => {
                 console.log(`Fetching max points for (nonentered) assignment ${assignment.dataset.id.substr(2)}`);
-                let response = await fetch(`https://api.schoology.com/v1/sections/${courseId}/assignments/${assignment.dataset.id.substr(2)}`, {
-                    headers: createApiAuthenticationHeaders(apiKeys)
-                });
+                let response = await fetchApi(`/sections/${courseId}/assignments/${assignment.dataset.id.substr(2)}`);
                 if (!response.ok) {
                     throw new Error(response.statusText);
                 }

--- a/js/materials.js
+++ b/js/materials.js
@@ -376,7 +376,7 @@
             // get the URL of the doc we want
             // it's an unauthenticated CDN url that expires (experimentation), returned as a redirect
             // unfortunately we need permissions for the extra domain
-            documentUrlsFromApi[documentId] = (await fetchWithApiAuthentication(fileData.converted_download_paths)).url;
+            documentUrlsFromApi[documentId] = (await fetchWithApiAuthentication(fileData.converted_download_path)).url;
         } else {
             // it's a file but not a supported type. TODO what to do? probably at least should show an unsupported method
         }

--- a/js/materials.js
+++ b/js/materials.js
@@ -46,7 +46,6 @@
     }
 
     let gradeLoadHooks = [];
-    let myApiKeys;
     let userId;
     let immediateGradeLoadInvoke = false;
     let loadedGradeContainer = null;
@@ -237,8 +236,7 @@
         }
     });
 
-    myApiKeys = await getApiKeys();
-    userId = myApiKeys[2];
+    userId = getUserId();
 
     // watch for new material DOM elements, and process them as they're added
     // needs a corresponding handler in the pagescript

--- a/js/preload.js
+++ b/js/preload.js
@@ -563,10 +563,17 @@ async function getApiKeys() {
 }
 
 /**
+ * Gets the current user's ID.
+ */
+function getUserId() {
+    return document.querySelector("#profile > a").href.match(/\d+/)[0];
+}
+
+/**
  * Gets the user's API credentials from the Schoology API key webpage, bypassing the cache.
  */
 async function getApiKeysDirect() {
-    let userId = document.querySelector("#profile > a").href.match(/\d+/)[0];
+    let userId = getUserId();
     var apiKeys = null;
     console.log(`Fetching API key for user ${userId}`);
     let html = await (await fetch("https://lms.lausd.net/api", { credentials: "same-origin" })).text();


### PR DESCRIPTION
Refactor Schoology API fetch calls, such that common code is in once place.

- Reduces code duplication
- The API key only has to be fetched once per page load
- Preemptive rate limiting implemented

I would appreciate a second pair of eyes and some more extensive testing going over this.

Fixes #73.