### PR TITLE
Add fetch wrapper through background page events

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -104,6 +104,55 @@ chrome.cookies.onChanged.addListener(function (changeInfo) {
     }
 });
 
+Logger.log("Adding HTTP request command listener");
+chrome.runtime.onMessage.addListener(
+    function (request, sender, sendResponse) {
+        if (request.type == "fetch" && request.url !== undefined) {
+            Logger.debug("Received fetch request for " + request.url);
+
+            (async function () {
+                let finalResponse = {};
+                let responseObj;
+                try {
+                    responseObj = await fetch(request.url, request.params);
+                } catch (e) {
+                    finalResponse.success = false;
+                    finalResponse.error = e;
+                    return finalResponse;
+                }
+
+                finalResponse.success = true;
+
+                finalResponse.headers = responseObj.headers;
+                finalResponse.ok = responseObj.ok;
+                finalResponse.redirected = responseObj.redirected;
+                finalResponse.status = responseObj.status;
+                finalResponse.statusText = responseObj.statusText;
+                finalResponse.type = responseObj.type;
+                finalResponse.url = responseObj.url;
+                finalResponse.useFinalURL = responseObj.useFinalURL;
+
+                try {
+                    switch (request.bodyReadType) {
+                        case "json":
+                            finalResponse.json = await responseObj.json();
+                            break;
+                        case "text":
+                            finalResponse.text = await responseObj.text();
+                            break;
+                    }
+                } catch (e) {
+                    finalResponse.bodyReadError = e || true;
+                }
+
+                return finalResponse;
+            })().then(x => sendResponse(x));
+
+            return true;
+        }
+    }
+);
+
 chrome.alarms.get("notification", function (alarm) {
     if (alarm) {
         Logger.log("Alarm is already registered");

--- a/js/preload.js
+++ b/js/preload.js
@@ -50,6 +50,38 @@ function getModalContents() {
     return modalContents;
 }
 
+function backgroundPageFetch(url, init, bodyReadType) {
+    return new Promise((resolve, reject) => {
+        chrome.runtime.sendMessage({ type: "fetch", url: url, params: init, bodyReadType: bodyReadType }, function (response) {
+            if (!response.success) {
+                reject(response.error);
+                return;
+            }
+
+            delete response.success;
+
+            let bodyReadError = response.bodyReadError;
+            delete response.bodyReadError;
+
+            let bodyContent = response[bodyReadType];
+            let readBodyTask = new Promise((readBodyResolve, readBodyReject) => {
+                if (bodyReadError) {
+                    if (bodyReadError === true) {
+                        readBodyReject();
+                    } else {
+                        readBodyReject(bodyReadError);
+                    }
+                } else {
+                    readBodyResolve(bodyContent);
+                }
+            });
+            response[bodyReadType] = () => readBodyTask;
+
+            resolve(response);
+        });
+    });
+}
+
 /**
  * Creates a fetch function wrapper which honors a rate limit.
  * 
@@ -89,7 +121,7 @@ function createFetchRateLimitWrapper(requestsPerInterval, interval) {
 
         if (callsThisCycle < requestsPerInterval) {
             callsThisCycle++;
-            return fetch.apply(this, arguments);
+            return backgroundPageFetch.apply(this, arguments);
         } else {
             // enqueue the request
             // basically try again later
@@ -130,15 +162,20 @@ function fetchApi(path) {
  * @param {string} url The URL to fetch.
  * @param {Object.<string, string>} [baseObj] The base set of headers. 
  * @param {boolean} [useRateLimit=true] Whether or not to use the internal Schoology API rate limit tracker. Defaults to true.
+ * @param {string} [bodyReadType="json"] The method with which the body should be read.
  */
-async function fetchWithApiAuthentication(url, baseObj, useRateLimit) {
+async function fetchWithApiAuthentication(url, baseObj, useRateLimit, bodyReadType) {
     if (useRateLimit === undefined) {
         useRateLimit = true;
     }
 
-    return await (useRateLimit ? preload_schoologyPlusApiRateLimitedFetch : fetch)(url, {
+    if (bodyReadType === undefined) {
+        bodyReadType = "json";
+    }
+
+    return await (useRateLimit ? preload_schoologyPlusApiRateLimitedFetch : backgroundPageFetch)(url, {
         headers: createApiAuthenticationHeaders(await getApiKeysInternal(), baseObj)
-    });
+    }, bodyReadType);
 }
 
 /**

--- a/js/preload.js
+++ b/js/preload.js
@@ -164,15 +164,7 @@ function fetchApi(path) {
  * @param {boolean} [useRateLimit=true] Whether or not to use the internal Schoology API rate limit tracker. Defaults to true.
  * @param {string} [bodyReadType="json"] The method with which the body should be read.
  */
-async function fetchWithApiAuthentication(url, baseObj, useRateLimit, bodyReadType) {
-    if (useRateLimit === undefined) {
-        useRateLimit = true;
-    }
-
-    if (bodyReadType === undefined) {
-        bodyReadType = "json";
-    }
-
+async function fetchWithApiAuthentication(url, baseObj, useRateLimit = true, bodyReadType = "json") {
     return await (useRateLimit ? preload_schoologyPlusApiRateLimitedFetch : backgroundPageFetch)(url, {
         headers: createApiAuthenticationHeaders(await getApiKeysInternal(), baseObj)
     }, bodyReadType);


### PR DESCRIPTION
Fixes #144. Adds a message handler to the background page, which does fetches and returns results to a Promise-based wrapper function in preload. That wrapper `backgroundPageFetch` function returns a promise which resolves to a Response-like object: basically a response, but without most of its functions; it's stuck with whatever got passed through the message handler.

The most notable annoyance of the wrapper function is that it needs a `bodyReadType` parameter to determine whether the response should be deserialized by the background page as a string or as JSON (or theoretically as other types). The value of this parameter determines the sole function on the returned Response-like object, either a `json` or `text` function returning a Promise.

This works in Chromium and Firefox On My Machine:tm:, but I'd like an extra pair of eyes, if possible, since this does go right to the core of our API call mechanics.