### PR TITLE
Version 5.2.1: Restore Past Courses to Schoology Plus

### DIFF
--- a/js/all.js
+++ b/js/all.js
@@ -329,6 +329,22 @@ let siteNavigationTileHelpers = {
 
         Logger.log("Processing courses dropdown mutation");
 
+        if (Setting.getValue("archivedCoursesButton") === "show") {
+            // aims to select the original "My Courses" link in the dropdown
+            let candidateLink = coursesDropdownContainer.querySelector(".CjR09._8a6xl._1tpub > a[href=\"/courses\"]._3ghFm");
+            if (candidateLink) {
+                // the obfuscated class name is the one Schoology uses to float these links right
+                let newContainer = createElement("div", ["courses-mycourses-droppeddown-link-container", "splus-addedtodynamicdropdown", "_3ghFm"], {}, [
+                    createElement("a", ["floating-contained-link", "splus-addedtodynamicdropdown"], {
+                        href: "/courses",
+                        textContent: "My Courses"
+                    })
+                ]);
+
+                candidateLink.replaceWith(newContainer);
+            }
+        }
+
         // rearrange spacing in the courses dropdown
         // Schoology has 4 tiles per row by default, we want 6
         const targetRowWidth = 6;

--- a/js/all.js
+++ b/js/all.js
@@ -338,6 +338,10 @@ let siteNavigationTileHelpers = {
                     createElement("a", ["floating-contained-link", "splus-addedtodynamicdropdown"], {
                         href: "/courses",
                         textContent: "My Courses"
+                    }),
+                    createElement("a", ["floating-contained-link", "splus-addedtodynamicdropdown"], {
+                        href: "/courses/mycourses/past",
+                        textContent: "Past Courses"
                     })
                 ]);
 

--- a/js/preload.js
+++ b/js/preload.js
@@ -536,6 +536,28 @@ function updateSettings(callback) {
                     element => element.value
                 ).control,
                 new Setting(
+                    "archivedCoursesButton",
+                    "Archived Courses Button",
+                    'Adds a link to see past/archived courses in the courses dropdown',
+                    "show",
+                    "select",
+                    {
+                        options: [
+                            {
+                                text: "Show",
+                                value: "show"
+                            },
+                            {
+                                text: "Hide",
+                                value: "hide"
+                            }
+                        ]
+                    },
+                    value => value,
+                    undefined,
+                    element => element.value
+                ).control,
+                new Setting(
                     "sessionCookiePersist",
                     "Stay Logged In",
                     "[Logout/login required] Stay logged in to Schoology when you restart your browser",

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
             "update_url": "https://aopell.me/SchoologyPlus/update.json"
         }
     },
-    "version": "5.2",
+    "version": "5.2.1",
     "icons": {
         "128": "imgs/icon@128.png",
         "64": "imgs/icon@64.png",


### PR DESCRIPTION
It appears Past Courses have been restored to LAUSD Schoology. This PR reverts some of the changes of 5.2 to restore references to Past Courses to Schoology Plus.