### PR TITLE
Ability to request new course icons

### DIFF
--- a/js/course.js
+++ b/js/course.js
@@ -94,20 +94,12 @@ function setCourseOptionsContent(modal, options) {
     }
 
     document.getElementById("request-course-icon-wrapper").outerHTML = "";
-    // Add request icon button only if default icon doesn't already exist
-    let hasDefaultIcon = (function (course) {
-        for (let iconPattern of icons) {
-            if (iconPattern.regex != "." && course.match(new RegExp(iconPattern.regex, 'i'))) {
-                return true;
-            }
-        }
-        return false;
-    })(options.courseName);
-    if (!hasDefaultIcon) {
+    // Add request icon button only if built-in icon doesn't already exist
+    if (!Theme.hasBuiltInIcon(options.courseName)) {
         modal.element.querySelector(".splus-modal-contents").appendChild(
             createElement("div", ["setting-entry"], { id: "request-course-icon-wrapper" }, [
                 createElement("h2", ["setting-title"], { textContent: "Request Icon: " }, [
-                    createElement("input", [], { type: "button", id: "request-course-icon-button", value: "Request Icon", onclick: () => window.open(`https://docs.google.com/forms/d/e/1FAIpQLSe-v0vRE4Obwkx6iL37aztz3kmpqYBBVxKEsdVxu8CZqk1OCQ/viewform?entry.50164059=${options.courseName}`, "_blank") })
+                    createElement("a", [], { id: "request-course-icon-link", textContent: "Request Icon", href: `${ICON_REQUEST_URL}${options.courseName}`, target: "_blank" })
                 ]),
                 createElement("p", ["setting-description"], { textContent: "Request that Schoology Plus adds a default course icon for this course" })
             ])

--- a/js/course.js
+++ b/js/course.js
@@ -93,15 +93,15 @@ function setCourseOptionsContent(modal, options) {
         }
     }
 
-    document.getElementById("request-course-icon-wrapper").outerHTML = "";
+    (document.getElementById("request-course-icon-wrapper") || {}).outerHTML = "";
     // Add request icon button only if built-in icon doesn't already exist
     if (!Theme.hasBuiltInIcon(options.courseName)) {
         modal.element.querySelector(".splus-modal-contents").appendChild(
             createElement("div", ["setting-entry"], { id: "request-course-icon-wrapper" }, [
                 createElement("h2", ["setting-title"], { textContent: "Request Icon: " }, [
-                    createElement("a", [], { id: "request-course-icon-link", textContent: "Request Icon", href: `${ICON_REQUEST_URL}${options.courseName}`, target: "_blank" })
+                    createElement("a", [], { id: "request-course-icon-link", textContent: "Click here to request a built-in icon for this course", href: `${ICON_REQUEST_URL}${options.courseName}`, target: "_blank" })
                 ]),
-                createElement("p", ["setting-description"], { textContent: "Request that Schoology Plus adds a default course icon for this course" })
+                createElement("p", ["setting-description"], { textContent: "Request that Schoology Plus adds a built-in course icon for this course" })
             ])
         );
     }

--- a/js/course.js
+++ b/js/course.js
@@ -93,6 +93,7 @@ function setCourseOptionsContent(modal, options) {
         }
     }
 
+    document.getElementById("request-course-icon-wrapper").outerHTML = "";
     // Add request icon button only if default icon doesn't already exist
     let hasDefaultIcon = (function (course) {
         for (let iconPattern of icons) {

--- a/js/course.js
+++ b/js/course.js
@@ -92,6 +92,26 @@ function setCourseOptionsContent(modal, options) {
             }
         }
     }
+
+    // Add request icon button only if default icon doesn't already exist
+    let hasDefaultIcon = (function (course) {
+        for (let iconPattern of icons) {
+            if (iconPattern.regex != "." && course.match(new RegExp(iconPattern.regex, 'i'))) {
+                return true;
+            }
+        }
+        return false;
+    })(options.courseName);
+    if (!hasDefaultIcon) {
+        modal.element.querySelector(".splus-modal-contents").appendChild(
+            createElement("div", ["setting-entry"], { id: "request-course-icon-wrapper" }, [
+                createElement("h2", ["setting-title"], { textContent: "Request Icon: " }, [
+                    createElement("input", [], { type: "button", id: "request-course-icon-button", value: "Request Icon", onclick: () => window.open(`https://docs.google.com/forms/d/e/1FAIpQLSe-v0vRE4Obwkx6iL37aztz3kmpqYBBVxKEsdVxu8CZqk1OCQ/viewform?entry.50164059=${options.courseName}`, "_blank") })
+                ]),
+                createElement("p", ["setting-description"], { textContent: "Request that Schoology Plus adds a default course icon for this course" })
+            ])
+        );
+    }
 }
 
 function createRow(percentage, symbol) {

--- a/js/theme.js
+++ b/js/theme.js
@@ -373,18 +373,19 @@ class Theme {
         }
 
         if (!shownMissingIconsNotification && coursesMissingDefaultIcons.size > 0) {
+            let coursesString = encodeURI(Array.from(coursesMissingDefaultIcons).join("\n"));
             showToast("Request New Course Icons?",
-                `${coursesMissingDefaultIcons.size} courses are missing Schoology Plus course icons`,
+                `${coursesMissingDefaultIcons.size} courses are missing Schoology Plus course icons. Would you like to request that icons be added for these courses?`,
                 "yellow",
                 {
                     buttons: [
-                        createToastButton("Request Icons", "suggest-icons-button", _ => alert(`Suggesting ${coursesMissingDefaultIcons}`)),
-                        createToastButton("Remind Me Later", "remind-later-button", _ => alert("Remind Later")),
-                        createToastButton("Don't Ask Again", "dont-ask-button", _ => alert("Don't ask again"))
+                        createToastButton("Yes", "suggest-icons-button", () => window.open(`https://docs.google.com/forms/d/e/1FAIpQLSe-v0vRE4Obwkx6iL37aztz3kmpqYBBVxKEsdVxu8CZqk1OCQ/viewform?entry.50164059=${coursesString}`, "_blank")),
+                        createToastButton("No", "nothing-button", () => showToast("You can request icons later from course options", "", "hsl(190, 100%, 50%)", { timeout: 5000 })),
                     ]
                 }
             )
             shownMissingIconsNotification = true;
+            Setting.setValue("toggle_stopTrackingMissingIcons", true);
         }
     }
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -4,6 +4,7 @@ let themeIconLoadElementContainer = document.createElement("div");
 themeIconLoadElementContainer.style.display = "none";
 
 let shownMissingIconsNotification = false;
+const ICON_REQUEST_URL = "https://docs.google.com/forms/d/e/1FAIpQLSe-v0vRE4Obwkx6iL37aztz3kmpqYBBVxKEsdVxu8CZqk1OCQ/viewform?entry.50164059=";
 
 class Theme {
     constructor(name, onApply, onUpdate) {
@@ -46,6 +47,15 @@ class Theme {
                 return iconPattern.url;
             }
         }
+    }
+
+    static hasBuiltInIcon(course) {
+        for (let iconPattern of icons) {
+            if (iconPattern.regex != "." && course.match(new RegExp(iconPattern.regex, 'i'))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static loadFromObject(theme) {
@@ -345,17 +355,7 @@ class Theme {
             }
 
             // ***** Tracking courses missing icons
-            if (Setting.getValue("toggle_stopTrackingMissingIcons")) continue;
-            let hasDefaultIcon = (function (course) {
-                for (let iconPattern of icons) {
-                    if (iconPattern.regex != "." && course.match(new RegExp(iconPattern.regex, 'i'))) {
-                        return true;
-                    }
-                }
-                return false;
-            })(arrow.courseTitle || arrow.parentElement.textContent);
-
-            if (!hasDefaultIcon) {
+            if (!Setting.getValue("toggle_stopTrackingMissingIcons") && !Theme.hasBuiltInIcon(arrow.courseTitle || arrow.parentElement.textContent)) {
                 coursesMissingDefaultIcons.add(arrow.courseTitle || arrow.parentElement.textContent);
             }
             // *****
@@ -375,11 +375,11 @@ class Theme {
         if (!shownMissingIconsNotification && coursesMissingDefaultIcons.size > 0) {
             let coursesString = encodeURI(Array.from(coursesMissingDefaultIcons).join("\n"));
             showToast("Request New Course Icons?",
-                `${coursesMissingDefaultIcons.size} courses are missing Schoology Plus course icons. Would you like to request that icons be added for these courses?`,
+                `${coursesMissingDefaultIcons.size} ${coursesMissingDefaultIcons.size == 1 ? "course is missing a Schoology Plus course icon. Would you like to request that an icon be added for this course?" : "courses are missing Schoology Plus course icons. Would you like to request that icons be added for these courses?"}`,
                 "yellow",
                 {
                     buttons: [
-                        createToastButton("Yes", "suggest-icons-button", () => window.open(`https://docs.google.com/forms/d/e/1FAIpQLSe-v0vRE4Obwkx6iL37aztz3kmpqYBBVxKEsdVxu8CZqk1OCQ/viewform?entry.50164059=${coursesString}`, "_blank")),
+                        createToastButton("Yes", "suggest-icons-button", () => window.open(`${ICON_REQUEST_URL}${coursesString}`, "_blank")),
                         createToastButton("No", "nothing-button", () => showToast("You can request icons later from course options", "", "hsl(190, 100%, 50%)", { timeout: 5000 })),
                     ]
                 }


### PR DESCRIPTION
This PR adds two methods of requesting new course icons for courses that don't already have them:
1. Toast notification on the grades page
2. Button in course options

Closes #122 

We should also potentially open a new issue regarding expanding default course icons depending on the department/A-G requirement of the course determined via LAUSD's course list.