### PR TITLE
Disable autocomplete on course nickname

### DIFF
--- a/js/course.js
+++ b/js/course.js
@@ -23,7 +23,7 @@ modals.push(new Modal("course-settings-modal", "Course Options", createElement("
         createElement("div", ["setting-entry"], {}, [
             createElement("h2", ["setting-title"], {}, [
                 createElement("label", ["centered-label"], { textContent: "Nickname: ", htmlFor: "setting-input-course-alias" }),
-                createElement("input", [], { type: "text", id: "setting-input-course-alias" }, [])
+                createElement("input", [], { type: "text", id: "setting-input-course-alias", autocomplete: "off" }, [])
             ]),
             createElement("p", ["setting-description"], { textContent: "A friendlier name for a course that shows anywhere the full name for the course would normally" })
         ]),


### PR DESCRIPTION
## What I Changed
> *Please enter a thorough and detailed description of *everything* you changed in this pull request.*

This adds the attribute `autocomplete=off` to the nickname field.

## Screenshots of Changes
> *Please include screenshots of each change you made either in this section or in the What I Changed section above. 
> Screenshots are required as we need to have a visual indication of what you did.*

![image](https://user-images.githubusercontent.com/10727862/103814515-a7398780-5016-11eb-8231-a6e1ec3577a8.png)
to
![image](https://user-images.githubusercontent.com/10727862/103814537-b15b8600-5016-11eb-94db-b0a354faab82.png)


## Issues Closed By This Pull Request
> *Please mention all issues this pull request addresses or closes. 
> If the issue is a GitHub issue, please reference it using the #9999 syntax. 
> If the issue is a Bug Bot issue, please reference it using it's shortcode, like DARK-9999 or BUG-9999. 
> Not all changes will necessarily have an issue ticket associated with them, but if they do you must mention it here*

Nothing that I could find.
