### PR TITLE
fixed what-if grade bug related to multiple semesters

### DIFF
--- a/js/grades.js
+++ b/js/grades.js
@@ -173,7 +173,8 @@ var fetchQueue = [];
                                 throw new Error("Assignment details could not be read");
                             }
 
-                            let pts = Number.parseFloat(json.section[0].period[0].assignment.filter(x => x.assignment_id == Number.parseInt(assignment.dataset.id.substr(2)))[0].max_points);
+                            const assignments = json.section[0].period.reduce((prevVal,curVal)=> prevVal.concat(curVal.assignment),[]);//combines the assignment arrays from each period
+                            let pts = Number.parseFloat(assignments.filter(x =>  x.assignment_id == assignment.dataset.id.substr(2))[0].max_points);
                             if (!assignment.classList.contains("dropped")) {
                                 max += pts;
                                 Logger.log(`Max points for assignment ${assignment.dataset.id.substr(2)} is ${pts}`);


### PR DESCRIPTION
## What I Changed
> *Please enter a thorough and detailed description of *everything* you changed in this pull request.*

Fixed a bug where what-if grades wouldn't enable and point total would display as <ERR> because there were missing assignments from second semester, and the code that looks through the class to find assignments was checking period[0], whereas these assignments were in period[1], so I modified grades.js so it checks the assignment lists for all periods.

## Screenshots of Changes
> *Please include screenshots of each change you made either in this section or in the What I Changed section above. 
> Screenshots are required as we need to have a visual indication of what you did.*

https://user-images.githubusercontent.com/48658337/106182727-1c9b0280-6154-11eb-8665-631214f6bd05.mp4

The three missing assignments you see are the ones that caused the error. 



## Issues Closed By This Pull Request
> *Please mention all issues this pull request addresses or closes. 
> If the issue is a GitHub issue, please reference it using the #9999 syntax. 
> If the issue is a Bug Bot issue, please reference it using it's shortcode, like DARK-9999 or BUG-9999. 
> Not all changes will necessarily have an issue ticket associated with them, but if they do you must mention it here*

Related to #228 but I'm not sure if it fixes that, because I didn't see multiple semesters in the screenshots for context in that issue.