### PR TITLE
Added FCPS Domain URL 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -61,7 +61,8 @@
         {
             "matches": [
                 "https://lms.lausd.net/*",
-                "https://*.schoology.com/*"
+                "https://*.schoology.com/*",
+                "https://lms.fcps.edu/*"
             ],
             "exclude_matches": [
                 "https://*.schoology.com/login*",
@@ -97,7 +98,8 @@
         {
             "matches": [
                 "https://lms.lausd.net/*",
-                "https://*.schoology.com/*"
+                "https://*.schoology.com/*",
+                "https://lms.fcps.edu/*"
             ],
             "exclude_matches": [
                 "https://*.schoology.com/login*",


### PR DESCRIPTION
## What I Changed
I've added a new URL/Domain to the ``` manifest.json ``` file, this now allows all students/staff members of FCPS to use Schoology+! Previously, even while logged in, the extension redirects to the schoology login page. Upon my changes, the Schoology+ extension now work perfectly!

## Screenshots of Changes
![githubThing](https://user-images.githubusercontent.com/61055258/132925593-a8f710ec-e23f-4782-beb8-e5eec86990e6.jpg)


