### PR TITLE
Add loader.js to the list of background scripts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -49,6 +49,7 @@
     "content_security_policy": "script-src 'self'; object-src 'self'",
     "background": {
         "scripts": [
+            "js/loader.js",
             "js/analytics.js",
             "lib/js/analytics.js",
             "lib/js/purify.min.js",


### PR DESCRIPTION
## What I Changed

I added loader.js to the list of background scripts, because it looks like analytics.js requires it. (Disclaimer: I am not a web developer, nor a user of this extension, so it's entirely possible I misunderstood the code–please do let me know if this isn't what you expected.)

## Screenshots of Changes

N/a

## Issues Closed By This Pull Request

N/a