### PR TITLE
Fix preview parity and contrast issues with the top navbar

### DIFF
--- a/css/all.css
+++ b/css/all.css
@@ -37,13 +37,16 @@
 
 /* Drop down menus (grades, applications, and user menu) */
 
+/* Kept old classes to remain compatible with older versions of Schoology */
 .StandardHeader-header-drop-menu-YShpU,
-.StandardHeader-header-drop-menu-YShpU {
+.Header-header-drop-menu-3SaYV {
     background-color: var(--hover-color) !important;
 }
 
 a.StandardHeader-header-drop-menu-YShpU:hover,
-.StandardHeader-header-drop-menu-YShpU li a:hover {
+.StandardHeader-header-drop-menu-YShpU li a:hover,
+a.Header-header-drop-menu-3SaYV:hover,
+.Header-header-drop-menu-3SaYV li a:hover {
     background-color: var(--background-color) !important;
 }
 

--- a/css/modern/all.css
+++ b/css/modern/all.css
@@ -267,6 +267,8 @@ variable-intellisense {
   color: var(--contrast-text) !important;
 }
 
+[modern=true]:root .Header-header-button-1EE8Y,
+[modern=true]:root .Header-header-button-active-GnvKh,
 [modern=true]:root .StandardHeader-header-button-1562K,
 [modern=true]:root [class*="StandardHeader-header-drop-menu-item-"],
 [modern=true]:root [class*="StandardHeader-header-drop-menu-"] li a *,


### PR DESCRIPTION
## What I Changed
> *Please enter a thorough and detailed description of *everything* you changed in this pull request.*

I modified some CSS to:
* fix the unreadable grades and profile dropdown
* change the color of the text and icons other than resources and calendar to contrast color

This fixes parity between the theme preview and the actual main page, as well as making many themes a lot easier to see.

## Screenshots of Changes
> *Please include screenshots of each change you made either in this section or in the What I Changed section above. 
> Screenshots are required as we need to have a visual indication of what you did.*

### Grades/Profile Dropdown

Theme: Default Modern Dark

Theme Preview (Same Before/After)
![image](https://user-images.githubusercontent.com/67439564/156908731-c1597b54-666f-47cb-8c08-45004cdc84e6.png)

Before
![image](https://user-images.githubusercontent.com/67439564/156908670-10b7735c-3580-4a88-a968-dfe54f710e15.png)
![image](https://user-images.githubusercontent.com/67439564/156908680-d2c21d99-9837-4300-85d6-1072583b6193.png)

After
![image](https://user-images.githubusercontent.com/67439564/156908702-5d4e54e3-f56e-4023-8b11-1229b5a03f65.png)
![image](https://user-images.githubusercontent.com/67439564/156908706-313c6bbd-5c3b-4819-b721-67f86a7228c5.png)

### Top bar contrast color

Theme: Default Modern Dark with the contrast color set to red to make issues more visible

Theme Preview (Same Before/After)
![image](https://user-images.githubusercontent.com/67439564/156908510-0eb9b452-3db1-4be4-8585-ef83e2c9e6d1.png)

Schoology Top Bar (Before)
![image](https://user-images.githubusercontent.com/67439564/156908559-7f5fab7e-afa9-4a4a-9c9c-637194d0ba96.png)

Schoology Top Bar (After)
![image](https://user-images.githubusercontent.com/67439564/156908563-896cc19c-2fa9-4f61-95ef-6e0770fdcf7d.png)

## Issues Closed By This Pull Request
> *Please mention all issues this pull request addresses or closes. 
> If the issue is a GitHub issue, please reference it using the #9999 syntax. 
> If the issue is a Bug Bot issue, please reference it using it's shortcode, like DARK-9999 or BUG-9999. 
> Not all changes will necessarily have an issue ticket associated with them, but if they do you must mention it here*

Fixes: #272
