### PR TITLE
Fix course catalog nicknames issue

### DIFF
--- a/js/all.js
+++ b/js/all.js
@@ -778,9 +778,9 @@ let siteNavigationTileHelpers = {
 
             let courseAlias;
             if (cardData.parentElement.href) {
-                let courseLinkMatch = cardData.parentElement.href.match(/\/course\/(\d+)\/?$/);
+                let courseLinkMatch = cardData.parentElement.href.split("/");
                 if (courseLinkMatch) {
-                    courseLinkMatch = courseLinkMatch[1];
+                    courseLinkMatch = courseLinkMatch.at(-2);
                 }
                 if (courseLinkMatch && Setting.getValue("courseAliases")) {
                     courseAlias = Setting.getValue("courseAliases")[courseLinkMatch];


### PR DESCRIPTION
## What I Changed
> *Please enter a thorough and detailed description of *everything* you changed in this pull request.*

Change the portion of js/all.js that renders the course catalog so the courseId from the link is pulled correctly.
Tested on Chrome and Firefox, but not Edge.

## Screenshots of Changes
> *Please include screenshots of each change you made either in this section or in the What I Changed section above. 
> Screenshots are required as we need to have a visual indication of what you did.*

*Portions of images blocked for privacy*
### Course catalog not working:
![image](https://user-images.githubusercontent.com/11432848/163590940-5638dba0-d0cf-4623-8c2b-900f9b84259a.png)
![image](https://user-images.githubusercontent.com/11432848/163591779-a33d677f-085d-4284-9539-407ec034b434.png)

### Course catalog working correctly:
![image](https://user-images.githubusercontent.com/11432848/163591154-8a0f4093-4937-4ce7-b825-489afe16e8c5.png)


## Issues Closed By This Pull Request
> *Please mention all issues this pull request addresses or closes. 
> If the issue is a GitHub issue, please reference it using the #9999 syntax. 
> If the issue is a Bug Bot issue, please reference it using it's shortcode, like DARK-9999 or BUG-9999. 
> Not all changes will necessarily have an issue ticket associated with them, but if they do you must mention it here*

Fixes #246