### PR TITLE
fix minimum grade calculation

### DIFF
--- a/js/grades.js
+++ b/js/grades.js
@@ -690,7 +690,7 @@ var fetchQueue = [];
                             let total = 0;
                             let totalPercentWeight = 0;
                             let catWeight = 0; // 0 to 1
-                            for (let category of perRow.parentElement.querySelectorAll(`.category-row[data-parent-id="${perRow.dataset.id}]"`)) {
+                            for (let category of perRow.parentElement.querySelectorAll(`.category-row[data-parent-id="${perRow.dataset.id}"]`)) {
                                 let weightPercentElement = category.getElementsByClassName("percentage-contrib")[0];
                                 if (!weightPercentElement) {
                                     continue;


### PR DESCRIPTION
## What I Changed
> *Please enter a thorough and detailed description of *everything* you changed in this pull request.*

Fixed the "Calculate Minimum Grade" function in the What-If Grades.
Fixed one typo in the `querySelectorAll` function. The quote was placed in the wrong position.

Before, "Calculate Minimum Grade" used to set all grades to 0, ignoring the request to maintain a certain overall grade.
Now, the "Calculate Minimum Grade" function works, maintaining the grade you specified.

## Screenshots of Changes
> *Please include screenshots of each change you made either in this section or in the What I Changed section above. 
> Screenshots are required as we need to have a visual indication of what you did.*

Before:
![image](https://user-images.githubusercontent.com/48170013/199868999-49fe1b32-381f-49bd-993b-b5336c4a2c71.png)

After: 
![image](https://user-images.githubusercontent.com/48170013/199869044-301d824c-ff1d-46af-9d00-618ae5038773.png)


## Issues Closed By This Pull Request
> *Please mention all issues this pull request addresses or closes. 
> If the issue is a GitHub issue, please reference it using the #9999 syntax. 
> If the issue is a Bug Bot issue, please reference it using it's shortcode, like DARK-9999 or BUG-9999. 
> Not all changes will necessarily have an issue ticket associated with them, but if they do you must mention it here*

Fixes https://github.com/aopell/SchoologyPlus/issues/273
