### PR TITLE
Add custom domain instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
     - [Schoology Plus Announcements](#schoology-plus-announcements)
   - [Schoology Plus Settings](#schoology-plus-settings)
     - [Theme Editor](#theme-editor)
+    - [Custom Domain Support](#custom-domain-support)
   - [Course Options](#course-options)
     - [Course Nicknames](#course-nicknames)
     - [Custom Grading Scales](#custom-grading-scales)
@@ -231,6 +232,13 @@ Schoology Plus has customizable settings, including but not limited to:
 *Image: The theme editor interface with an example of a custom Black and White theme*
 
 Schoology Plus is equipped with a fully-featured theme editor, allowing you to create your own custom theme. The theme editor allows you to preview your changes to the interface, including colors, logos, cursors, and custom icons. To learn more about the theme editor, see the [Theme Editor help page](/docs/themes).
+
+### Custom Domain Support
+Schoology Plus can be configured to work with your school's custom Schoology instance. Simply navigate to the homepage of your school's Schoology implementation, then right click the extension and select "Enable Schoolgy Plus on this domain"
+
+![Custom Domains](https://i.imgur.com/WYgCVES.png)
+
+*Image: The option to enable Schoology Plus for your school's domain can be found by right-clicking the extension.*
 
 ## Course Options
 


### PR DESCRIPTION
## What I Changed
- Added instructions in the README on using custom domain support (#245) 

- Before, it was unclear how to enable Schoology Plus for your school's domain (I was able to make an educated guess based on some issues and PRs, but other than that I could not find it mentioned at all)

## Screenshots of Changes
Added a snippet on Custom Domain Support inside ```Schoology Plus Settings```, under ```Theme Editor```:
![image](https://user-images.githubusercontent.com/20372625/202871963-6a3615f9-7077-4029-9ab2-c7fe23fe1b6b.png)

Added a link in the table of contents:
![image](https://user-images.githubusercontent.com/20372625/202872002-2bff90e6-5c92-4b30-a573-a7e497815224.png)

## Issues Closed By This Pull Request
\- None -