### PR TITLE
Added dropdown menu for changing theme in settings

### DIFF
--- a/js/preload.js
+++ b/js/preload.js
@@ -417,6 +417,23 @@ function updateSettings(callback) {
             return defaultGradingScale;
         }
 
+        let themeOptions = [];
+
+        for (let theme of __defaultThemes) {
+            if(theme.name.includes('LAUSD') && storageContents.defaultDomain !== "lms.lausd.net") continue;
+            themeOptions.push({
+                text: theme.name,
+                value: theme.name
+            });
+        }
+
+        for (let theme of storageContents.themes) {
+            themeOptions.push({
+                text: theme.name,
+                value: theme.name
+            });
+        }
+
         if (firstLoad) {
             if (storageContents.themes) {
                 for (let t of storageContents.themes) {
@@ -433,15 +450,30 @@ function updateSettings(callback) {
         modalContents = createElement("div", [], undefined, [
             createElement("div", ["splus-modal-contents"], {}, [
                 new Setting(
-                    "theme",
-                    "Theme",
+                    "themeEditor",
+                    "Theme Editor",
                     "Click to open the theme editor to create, edit, or select a theme",
-                    "Schoology Plus",
+                    "Theme Editor",
                     "button",
                     {},
-                    value => value || "Schoology Plus",
-                    event => location.href = chrome.runtime.getURL("/theme-editor.html"),
-                    element => element.value
+                    value => "Theme Editor",
+                    event => location.href = chrome.runtime.getURL("/theme-editor.html")
+                ).control,
+                new Setting(
+                    "theme",
+                    "Theme",
+                    "[Reload required] Changes the theme of Schoology Plus",
+                    "Schoology Plus",
+                    "select",
+                    {
+                        options: themeOptions
+                    },
+                    value => value,
+                    undefined,
+                    element => {
+                        chrome.storage.sync.set({"theme": element.value}); 
+                        return element.value
+                    }
                 ).control,
                 new Setting(
                     "notifications",


### PR DESCRIPTION
## What I Changed
> *Please enter a thorough and detailed description of *everything* you changed in this pull request.*

I changed the button in the settings popup to open the theme editor to just say "Theme editor", and I added an additional setting which is a dropdown menu allowing you to easily change the theme without leaving Schoology. To do this I also had to add another variable called `themeOptions` which contains a list of all themes (not including LAUSD themes when your not using LAUSD Schoology) in the format used to create a dropdown menu.

## Screenshots of Changes
> *Please include screenshots of each change you made either in this section or in the What I Changed section above. 
> Screenshots are required as we need to have a visual indication of what you did.*

Old:
<img width="834" alt="Screenshot 2023-03-04 at 3 15 25 PM" src="https://user-images.githubusercontent.com/84212123/222926882-a8e60db9-ed2e-4072-b550-a0a7cc2f7d22.png">

New:
<img width="822" alt="Screenshot 2023-03-04 at 3 15 46 PM" src="https://user-images.githubusercontent.com/84212123/222926890-8295ddf8-3fdb-48ff-87fc-331477272d54.png">
<img width="821" alt="Screenshot 2023-03-04 at 3 16 09 PM" src="https://user-images.githubusercontent.com/84212123/222926892-6da1f61f-39bd-4997-a6a7-91b4a67c07ee.png">

## Issues Closed By This Pull Request
> *Please mention all issues this pull request addresses or closes. 
> If the issue is a GitHub issue, please reference it using the #9999 syntax. 
> If the issue is a Bug Bot issue, please reference it using it's shortcode, like DARK-9999 or BUG-9999. 
> Not all changes will necessarily have an issue ticket associated with them, but if they do you must mention it here*

N/A
