### PR TITLE
Fix Incorrect "Timer" Sizes

### DIFF
--- a/css/all.css
+++ b/css/all.css
@@ -766,6 +766,20 @@ a._3_bfp {
     display: none !important;
 }
 
+/* ---- Hotfix for missized timer icons ---- */
+.upcoming-list .upcoming-event {
+    align-items: flex-start !important;
+}
+
+.upcoming-list .upcoming-event * {
+    flex-basis: fit-content;
+}
+
+.upcoming-list .upcoming-event > *:not(h4) {
+    margin-top: 2rem !important;
+}
+/* ---------------------------------------- */
+
 .splus-mark-completed-check .infotip {
     width: 90% !important;
 }


### PR DESCRIPTION
## What I Changed
Minor CSS edits

## Screenshots of Changes
See original issue for comparison

<img width="428" alt="schoology_timer_size_fixed" src="https://user-images.githubusercontent.com/112342179/230514942-d3ea2e19-8852-4644-b2c1-594179c97899.png">

_Side note: I had to purposefully leave an assignment incomplete to test the "overdue" timer, is there an easier way to test features?_


## Issues Closed By This Pull Request

Resolves #304
