### PR TITLE
Fixed Bugged Percent

### DIFF
--- a/css/grades.css
+++ b/css/grades.css
@@ -20,6 +20,11 @@ div.tier-injected-score {
     text-align: right;
 }
 
+/* this needs to be on its own to be more specific and override schoology */
+.td-content-wrapper {
+    display: block !important;
+}
+
 .grade-column-center {
     text-align: center !important;
     padding-right: 10px !important;


### PR DESCRIPTION
## What I Changed
Added more specific styles to override Schoology's CSS and allow for the percent grade to be displayed below.

Before the `td-content-wrapper` class was styled with `display: flex;`, which messes with the injected percent.
Now the `td-content-wrapper` class is styled with `display: block;` which fixes this.

## Screenshots of Changes
> *Please include screenshots of each change you made either in this section or in the What I Changed section above. 
> Screenshots are required as we need to have a visual indication of what you did.*

### Before:
![image](https://github.com/aopell/SchoologyPlus/assets/48170013/08eef802-f8f4-4488-be63-182ff04da2ff)

### After:
![image](https://github.com/aopell/SchoologyPlus/assets/48170013/85e88c9c-13e7-4565-87e6-a94ce16a0efb)


## Issues Closed By This Pull Request
> *Please mention all issues this pull request addresses or closes. 
> If the issue is a GitHub issue, please reference it using the #9999 syntax. 
> If the issue is a Bug Bot issue, please reference it using it's shortcode, like DARK-9999 or BUG-9999. 
> Not all changes will necessarily have an issue ticket associated with them, but if they do you must mention it here*

N/A
