### PR TITLE
Fix What-If Grades for Assignments with No Grade

### DIFF
--- a/js/grades.js
+++ b/js/grades.js
@@ -201,6 +201,12 @@ var fetchQueue = [];
                         let processAssignment = async function (assignment) {
                             let maxGrade = assignment.querySelector(".max-grade");
                             let score = assignment.querySelector(".rounded-grade") || assignment.querySelector(".rubric-grade-value");
+
+                            if (!maxGrade && !score && !assignment.querySelector(".no-grade")) {
+                                // some schoology assignments don't display a grade, so we need to create a placeholder
+                                assignment.querySelector(".grade-column > .td-content-wrapper").prepend(createElement("span", ["no-grade"], { textContent: "—" }));
+                            }
+
                             if (score) {
                                 let assignmentScore = Number.parseFloat(score.textContent);
                                 let assignmentMax = Number.parseFloat(maxGrade.textContent.substring(3));


### PR DESCRIPTION
## What I Changed

Schoology Plus normally deals with assignments with a missing grade assuming that Schoology places a `no-grade` placeholder, but in some cases there is no placeholder. This most likely occurs when the teacher is not using a standard percentage grading system, instead using standards-based grading or similar systems. In this rare case, Schoology Plus prevents you from editing grades. 

### Picture of Assignments with No Grade Placeholder (no placeholder even on vanilla Schoology)
![image](https://github.com/aopell/SchoologyPlus/assets/48170013/d6602416-977a-422f-9930-6fb5a86ef119)

### Resulting Error When Trying to Edit Grade
![image](https://github.com/aopell/SchoologyPlus/assets/48170013/c2931967-94e2-420c-8113-d3f236bc6826)

## Screenshots of Changes
To fix this, I check if there is no score, no max score, and no `no-grade` placeholder. If all of these conditions are met, I create a placeholder.

### Fixed
![image](https://github.com/aopell/SchoologyPlus/assets/48170013/ed160a32-7e3a-4c3b-9b63-410d089311c7)

### Fixed: What-If Grades Enabled
![image](https://github.com/aopell/SchoologyPlus/assets/48170013/91640114-ac5d-44d5-89f8-2dcd30d20aea)

## Issues Closed By This Pull Request
[Discord: #support-forum > What-If grades not working for one class](https://discord.com/channels/526898202495025172/1183947737201393684)
