### PR TITLE
centered menu icons in resource submission modal

### DIFF
--- a/src/styles/all.scss
+++ b/src/styles/all.scss
@@ -1314,6 +1314,16 @@ Should not be shown
     padding-top: 10px !important;
 }
 
+/*
+Centers menu icons in the Schoology resource submission modal.
+*/
+#resources-left-menu-wrapper a {
+    display: flex !important;
+    flex-direction: column !important;
+    justify-items: center !important;
+    align-items: center !important;
+}
+
 .splus-is-grades-page {
     .gradebook-course-title span.injected-title-grade {
         float: right;


### PR DESCRIPTION
I added a bit of CSS to center the icons in the menu on the left side of the modal that shows up when you submit resources.

# Before
<img width="862" alt="before" src="https://github.com/user-attachments/assets/0c924448-b739-433e-bd13-ab73cce28714">

# After
<img width="860" alt="after" src="https://github.com/user-attachments/assets/91dbdf5f-ff25-4c27-95d2-82d3f55fc759">
